### PR TITLE
AWS and Azure broker docu-checker resource naming fixes (kyma#5185)

### DIFF
--- a/addons/aws-service-broker-0.0.1/chart/aws-service-broker/templates/docs-check-job.yaml
+++ b/addons/aws-service-broker-0.0.1/chart/aws-service-broker/templates/docs-check-job.yaml
@@ -16,7 +16,7 @@ spec:
             annotations:
                 sidecar.istio.io/inject: "false"
         spec:
-            serviceAccountName: {{ include "fullname" . }}-docu-checker
+            serviceAccountName: {{ include "fullname" . | trunc 60 }}-dc
             restartPolicy: Never
             containers:
                 - name: docu-checker

--- a/addons/aws-service-broker-0.0.1/chart/aws-service-broker/templates/jobs-sa.yaml
+++ b/addons/aws-service-broker-0.0.1/chart/aws-service-broker/templates/jobs-sa.yaml
@@ -1,7 +1,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-    name: {{ template "fullname" . }}-docu-checker
+    name: {{ include "fullname" . | trunc 60 }}-dc
     labels:
         app: {{ template "fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -45,7 +45,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-    name: {{ template "fullname" . }}-docu-checker
+    name: {{ include "fullname" . | trunc 60 }}-dc
     labels:
         app: {{ template "fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -75,7 +75,7 @@ roleRef:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-    name: {{ template "fullname" . }}-docu-checker
+    name: {{ include "fullname" . | trunc 60 }}-dc
     labels:
         app: {{ template "fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -83,9 +83,9 @@ metadata:
         heritage: "{{ .Release.Service }}"
 subjects:
     - kind: ServiceAccount
-      name: {{ template "fullname" . }}-docu-checker
+      name: {{ include "fullname" . | trunc 60 }}-dc
       namespace: {{ .Release.Namespace }}
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role
-    name: {{ template "fullname" . }}-docu-checker
+    name: {{ include "fullname" . | trunc 60 }}-dc

--- a/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/job.yaml
+++ b/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/job.yaml
@@ -16,7 +16,7 @@ spec:
             annotations:
                 sidecar.istio.io/inject: "false"
         spec:
-            serviceAccountName: {{ include "fullname" . }}-docu-checker
+            serviceAccountName: {{ include "fullname" . | trunc 60 }}-dc
             restartPolicy: Never
             containers:
                 - name: docu-checker

--- a/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/role-binding.yaml
+++ b/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/role-binding.yaml
@@ -1,7 +1,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-    name: {{ template "fullname" . }}-docu-checker
+    name: {{ include "fullname" . | trunc 60 }}-dc
     labels:
         app: {{ template "fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -9,9 +9,9 @@ metadata:
         heritage: "{{ .Release.Service }}"
 subjects:
     - kind: ServiceAccount
-      name: {{ template "fullname" . }}-docu-checker
+      name: {{ include "fullname" . | trunc 60 }}-dc
       namespace: {{ .Release.Namespace }}
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role
-    name: {{ template "fullname" . }}-docu-checker
+    name: {{ include "fullname" . | trunc 60 }}-dc

--- a/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/role.yaml
+++ b/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/role.yaml
@@ -1,7 +1,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-    name: {{ template "fullname" . }}-docu-checker
+    name: {{ include "fullname" . | trunc 60 }}-dc
     labels:
         app: {{ template "fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/sa.yaml
+++ b/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/sa.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-    name: {{ template "fullname" . }}-docu-checker
+    name: {{ include "fullname" . | trunc 60 }}-dc
     labels:
         app: {{ template "fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- limit resource names created in aws and azure brokers charts to max 63 chars. Docu-checker templates/resources were possibly violating 63 chars constraints.


**Related issue(s)**
Fixes https://github.com/kyma-project/kyma/issues/5185 

Tested/verified only with Azure.