### PR TITLE
Rename DocsTopics to AssetGroups in broker charts

### DIFF
--- a/addons/aws-service-broker-0.0.1/chart/aws-service-broker/templates/docu/docs.yaml
+++ b/addons/aws-service-broker-0.0.1/chart/aws-service-broker/templates/docu/docs.yaml
@@ -1,10 +1,10 @@
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 3dc60f71-bfed-518e-95c5-a16c0017b591
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -14,13 +14,13 @@ spec:
       mode: single
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/athena/README.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 37bcdc91-6a5b-5fa1-8c09-e2bd42c9cb1b
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -31,13 +31,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/emr/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 0c7746ca-1741-52fb-bea4-d542a2f35b26
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -48,13 +48,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/kinesis/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 1b6a9c33-272d-5d20-b98a-e1d1a4653ba8
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -65,13 +65,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/rdsmariadb/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 66648c78-139c-50e6-8151-b9eef85fc829
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -82,13 +82,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/translate/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 7c142ff0-89dc-5c76-84aa-a98144d3b829
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -99,13 +99,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/kms/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 84ea1a30-46ec-5627-9bec-07684ac15048
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -116,13 +116,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/rekognition/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 8d1e10d7-2c9f-5c00-9ad1-48e094d1b3f0
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -133,13 +133,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/sns/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 9cc89cca-c31e-5904-a6b7-bcf26b7a06d5
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -150,13 +150,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/dynamodb/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: a04ce9fc-cb4d-5f7a-8fa7-9d14c1b64e17
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -167,13 +167,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/redshift/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: a603c243-515d-5e76-9a60-237f3a585cdb
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -184,13 +184,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/sqs/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: ac0c50f6-1dd6-5881-ad40-45afd094e1a7
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -201,13 +201,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/polly/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: b72a3d43-a8a7-5bb8-973d-270faab35a7a
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -218,13 +218,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/rdsmysql/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: bc2fcbc1-8536-53c7-8930-dd4de81613d6
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -235,13 +235,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/s3/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: c6a36102-f1e7-506c-bd63-19252168eac5
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -252,13 +252,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/lex/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: e1311d9c-788b-5c36-a616-50acb7f3a467
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -269,13 +269,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/route53/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: feda14f7-421c-5887-9eb2-eb4ac4d74603
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -286,13 +286,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/elasticache/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: dbc04fed-3954-5ceb-b085-d929efe9435e
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -303,13 +303,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/master/templates/elasticsearch/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: aab2ed5a-f125-5a7a-8263-59167fb4dff1
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -320,13 +320,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/master/templates/documentdb/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 63dc48b9-a2af-566e-ae39-8ecace979307
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -337,13 +337,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/rdspostgresql/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: e369c182-f1fd-5cde-9710-946fc727de1b
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -354,13 +354,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/master/templates/rdsoracle/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 168dd9f3-b0e6-553c-b0f3-e378ebf272a8
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -371,13 +371,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/master/templates/rdsmssql/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: a20b78e9-04c0-5c2f-8625-e14c8629bf98
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -388,13 +388,13 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/master/templates/aurorapostgresql/README.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 72a6b8d8-489d-52a2-85c4-3935f3f0f93f
   namespace: {{ .Release.Namespace }}
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:

--- a/addons/aws-service-broker-0.0.1/chart/aws-service-broker/templates/docu/docs.yaml
+++ b/addons/aws-service-broker-0.0.1/chart/aws-service-broker/templates/docu/docs.yaml
@@ -1,4 +1,4 @@
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 3dc60f71-bfed-518e-95c5-a16c0017b591
@@ -14,7 +14,7 @@ spec:
       mode: single
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/athena/README.md"
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 37bcdc91-6a5b-5fa1-8c09-e2bd42c9cb1b
@@ -31,7 +31,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/emr/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 0c7746ca-1741-52fb-bea4-d542a2f35b26
@@ -48,7 +48,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/kinesis/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 1b6a9c33-272d-5d20-b98a-e1d1a4653ba8
@@ -65,7 +65,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/rdsmariadb/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 66648c78-139c-50e6-8151-b9eef85fc829
@@ -82,7 +82,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/translate/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 7c142ff0-89dc-5c76-84aa-a98144d3b829
@@ -99,7 +99,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/kms/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 84ea1a30-46ec-5627-9bec-07684ac15048
@@ -116,7 +116,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/rekognition/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 8d1e10d7-2c9f-5c00-9ad1-48e094d1b3f0
@@ -133,7 +133,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/sns/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 9cc89cca-c31e-5904-a6b7-bcf26b7a06d5
@@ -150,7 +150,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/dynamodb/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: a04ce9fc-cb4d-5f7a-8fa7-9d14c1b64e17
@@ -167,7 +167,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/redshift/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: a603c243-515d-5e76-9a60-237f3a585cdb
@@ -184,7 +184,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/sqs/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: ac0c50f6-1dd6-5881-ad40-45afd094e1a7
@@ -201,7 +201,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/polly/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: b72a3d43-a8a7-5bb8-973d-270faab35a7a
@@ -218,7 +218,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/rdsmysql/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: bc2fcbc1-8536-53c7-8930-dd4de81613d6
@@ -235,7 +235,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/s3/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: c6a36102-f1e7-506c-bd63-19252168eac5
@@ -252,7 +252,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/lex/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: e1311d9c-788b-5c36-a616-50acb7f3a467
@@ -269,7 +269,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/route53/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: feda14f7-421c-5887-9eb2-eb4ac4d74603
@@ -286,7 +286,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/elasticache/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: dbc04fed-3954-5ceb-b085-d929efe9435e
@@ -303,7 +303,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/master/templates/elasticsearch/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: aab2ed5a-f125-5a7a-8263-59167fb4dff1
@@ -320,7 +320,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/master/templates/documentdb/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 63dc48b9-a2af-566e-ae39-8ecace979307
@@ -337,7 +337,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/v{{ .Chart.Version }}/templates/rdspostgresql/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: e369c182-f1fd-5cde-9710-946fc727de1b
@@ -354,7 +354,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/master/templates/rdsoracle/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 168dd9f3-b0e6-553c-b0f3-e378ebf272a8
@@ -371,7 +371,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/master/templates/rdsmssql/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: a20b78e9-04c0-5c2f-8625-e14c8629bf98
@@ -388,7 +388,7 @@ spec:
       url: "https://raw.githubusercontent.com/awslabs/aws-servicebroker/master/templates/aurorapostgresql/README.md"
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 72a6b8d8-489d-52a2-85c4-3935f3f0f93f

--- a/addons/aws-service-broker-0.0.1/chart/aws-service-broker/templates/docu/job.yaml
+++ b/addons/aws-service-broker-0.0.1/chart/aws-service-broker/templates/docu/job.yaml
@@ -27,13 +27,13 @@ spec:
                       - |
                           while true
                           do
-                            echo "Get list of not ready DocsTopic:"
-                            lines=$(kubectl get DocsTopic -l chart=${LABEL_CHART} -l release=${LABEL_RELEASE} -n ${NS} \
+                            echo "Get list of not ready AssetGroup:"
+                            lines=$(kubectl get AssetGroup -l chart=${LABEL_CHART} -l release=${LABEL_RELEASE} -n ${NS} \
                               --no-headers -o custom-columns=name:.metadata.name,phase:.status.phase | awk '$2!="Ready"' | wc -l)
-                            echo "Got ${lines} not ready Docs Topic"
+                            echo "Got ${lines} not ready Asset Group"
                             if [[ "${lines}" -eq "0" ]];
                             then
-                                echo "Every DocsTopic is processed. Completed."
+                                echo "Every AssetGroup is processed. Completed."
                                 exit 0
                             fi
                             sleep 3

--- a/addons/aws-service-broker-0.0.1/chart/aws-service-broker/templates/docu/role.yaml
+++ b/addons/aws-service-broker-0.0.1/chart/aws-service-broker/templates/docu/role.yaml
@@ -8,6 +8,6 @@ metadata:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
 rules:
-    - apiGroups: ["cms.kyma-project.io"]
-      resources: ["docstopics"]
+    - apiGroups: ["rafter.kyma-project.io"]
+      resources: ["assetgroups"]
       verbs: ["list"]

--- a/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/docs.yaml
+++ b/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/docs.yaml
@@ -1,11 +1,11 @@
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 66130ee7-451b-4c61-8b78-d5c426a06f3e
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -18,12 +18,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-appinsights/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 5f5252a0-6922-4a0c-a755-f9be70d7c79b
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -36,12 +36,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-cosmosdb/graph-account/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 8797a079-5346-4e84-8018-b7d5ea5c0e3a
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -54,12 +54,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-cosmosdb/mongo-account/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 58d9fbbd-7041-4dbe-aabe-6268cd31de84
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -72,12 +72,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-cosmosdb/sql/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 6330de6f-a561-43ea-a15e-b99f44d183e6
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -90,12 +90,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-cosmosdb/sql-account/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 87c5132a-6d76-40c6-9621-0c7b7542571b
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -108,12 +108,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-cosmosdb/sql-database/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 37915cad-5259-470d-a7aa-207ba89ada8c
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -126,12 +126,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-cosmosdb/table-account/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 7bade660-32f1-4fd7-b9e6-d416d975170b
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -144,12 +144,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-eventhubs/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: afd72c3b-6c2d-40f2-ad0d-d90467989be5
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -162,12 +162,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-iothub/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: d90c881e-c9bb-4e07-a87b-fcfe87e03276
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -180,12 +180,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-keyvault/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 2bbc160c-e279-4757-a6b6-4c0a4822d0aa
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -198,12 +198,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssql/v12.0/database/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: b0b2a2f7-9b5e-4692-8b94-24fe2f6a9a8e
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -216,12 +216,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssql/v12.0/database-from-existing/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: a7454e0e-be2c-46ac-b55f-8c4278117525
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -234,12 +234,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssql/v12.0/dbms/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: fb9bc99e-0aa9-11e6-8a8a-000d3a002ed5
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -252,12 +252,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssql/v12.0/dbms-and-database/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: c9bd94e7-5b7d-4b20-96e6-c5678f99d997
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -270,12 +270,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssql/v12.0/dbms-registered/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 2eb94a7e-5a7c-46f9-b9d2-ff769f215845
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -288,12 +288,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssqldr/v12.0/database-pair/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: e18a9861-5740-4e1a-9bd0-6f0fc3e4d12f
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -307,12 +307,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssqldr/v12.0/database-pair-from-existing/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 505ae87a-5cd8-4aeb-b7ea-809dd249dc1f
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -326,12 +326,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssqldr/v12.0/database-pair-from-existing-primary/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 8480271a-f4c7-4232-b2b7-7f33391728f7
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -345,12 +345,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssqldr/v12.0/database-pair-registered/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 00ce53a3-d6c3-4c24-8cb2-3f48d3b161d8
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -363,12 +363,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssqldr/v12.0/dbms-pair-registered/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 6704ae59-3eae-49e9-82b4-4cbcc00edf08
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -381,12 +381,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mysql/v5.7/database/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 30e7b836-199d-4335-b83d-adc7d23a95c2
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -399,12 +399,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mysql/v5.7/dbms/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 997b8372-8dac-40ac-ae65-758b4a5075a5
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -417,12 +417,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mysql/v5.7/dbms-and-database/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 32d3b4e0-e68f-4e96-93d4-35fd380f0874
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -435,12 +435,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-postgresql/v10/postgresql/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 1fd01042-3b70-4612-ac19-9ced0b2a1525
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -453,12 +453,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-postgresql/v10/postgresql-database/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: cabd3125-5a13-46ea-afad-a69582af9578
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -471,12 +471,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-postgresql/v10/postgresql-dbms/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: b43b4bba-5741-4d98-a10b-17dc5cee0175
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -489,12 +489,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-postgresql/v9.6/postgresql/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 25434f16-d762-41c7-bbdd-8045d7f74ca6
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -507,12 +507,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-postgresql/v9.6/postgresql-database/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: d3f74b44-79bc-4d1e-bf7d-c247c2b851f9
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -525,12 +525,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-postgresql/v9.6/postgresql-dbms/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 0346088a-d4b2-4478-aa32-f18e295ec1d9
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -543,12 +543,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-rediscache/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 6dc44338-2f13-4bc5-9247-5b1b3c5462d3
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -561,12 +561,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-servicebus/servicebus-namespace/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 0e93fbb8-7904-43a5-82db-81c7d3886a24
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -579,12 +579,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-servicebus/servicebus-queue/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: dc6d1545-4391-4c7e-ac7e-a8463787fb93
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -597,12 +597,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-servicebus/servicebus-topic/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 1a5b4582-29a3-48c5-9cac-511fd8c52756
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -615,12 +615,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-storage/blob-account/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: d799916e-3faf-4bdf-a48b-bf5012a2d38c
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -633,12 +633,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-storage/blob-account-and-container/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: fb6ce656-c16d-4b48-aff9-286714298af8
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -651,12 +651,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-storage/blob-container/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: d10ea062-b627-41e8-a240-543b60030694
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -669,12 +669,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-storage/v1-storage-account/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 9a3e28fe-8c02-49da-9b35-1b054eb06c95
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -687,12 +687,12 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-storage/v2-storage-account/
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1alpha1
+kind: AssetGroup
 metadata:
   name: 8f6c848a-4ce1-4a69-9248-63545d3e7e9c
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:

--- a/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/docs.yaml
+++ b/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/docs.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 66130ee7-451b-4c61-8b78-d5c426a06f3e
@@ -18,7 +18,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-appinsights/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 5f5252a0-6922-4a0c-a755-f9be70d7c79b
@@ -36,7 +36,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-cosmosdb/graph-account/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 8797a079-5346-4e84-8018-b7d5ea5c0e3a
@@ -54,7 +54,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-cosmosdb/mongo-account/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 58d9fbbd-7041-4dbe-aabe-6268cd31de84
@@ -72,7 +72,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-cosmosdb/sql/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 6330de6f-a561-43ea-a15e-b99f44d183e6
@@ -90,7 +90,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-cosmosdb/sql-account/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 87c5132a-6d76-40c6-9621-0c7b7542571b
@@ -108,7 +108,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-cosmosdb/sql-database/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 37915cad-5259-470d-a7aa-207ba89ada8c
@@ -126,7 +126,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-cosmosdb/table-account/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 7bade660-32f1-4fd7-b9e6-d416d975170b
@@ -144,7 +144,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-eventhubs/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: afd72c3b-6c2d-40f2-ad0d-d90467989be5
@@ -162,7 +162,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-iothub/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: d90c881e-c9bb-4e07-a87b-fcfe87e03276
@@ -180,7 +180,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-keyvault/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 2bbc160c-e279-4757-a6b6-4c0a4822d0aa
@@ -198,7 +198,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssql/v12.0/database/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: b0b2a2f7-9b5e-4692-8b94-24fe2f6a9a8e
@@ -216,7 +216,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssql/v12.0/database-from-existing/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: a7454e0e-be2c-46ac-b55f-8c4278117525
@@ -234,7 +234,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssql/v12.0/dbms/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: fb9bc99e-0aa9-11e6-8a8a-000d3a002ed5
@@ -252,7 +252,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssql/v12.0/dbms-and-database/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: c9bd94e7-5b7d-4b20-96e6-c5678f99d997
@@ -270,7 +270,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssql/v12.0/dbms-registered/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 2eb94a7e-5a7c-46f9-b9d2-ff769f215845
@@ -288,7 +288,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssqldr/v12.0/database-pair/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: e18a9861-5740-4e1a-9bd0-6f0fc3e4d12f
@@ -307,7 +307,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssqldr/v12.0/database-pair-from-existing/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 505ae87a-5cd8-4aeb-b7ea-809dd249dc1f
@@ -326,7 +326,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssqldr/v12.0/database-pair-from-existing-primary/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 8480271a-f4c7-4232-b2b7-7f33391728f7
@@ -345,7 +345,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssqldr/v12.0/database-pair-registered/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 00ce53a3-d6c3-4c24-8cb2-3f48d3b161d8
@@ -363,7 +363,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mssqldr/v12.0/dbms-pair-registered/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 6704ae59-3eae-49e9-82b4-4cbcc00edf08
@@ -381,7 +381,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mysql/v5.7/database/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 30e7b836-199d-4335-b83d-adc7d23a95c2
@@ -399,7 +399,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mysql/v5.7/dbms/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 997b8372-8dac-40ac-ae65-758b4a5075a5
@@ -417,7 +417,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-mysql/v5.7/dbms-and-database/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 32d3b4e0-e68f-4e96-93d4-35fd380f0874
@@ -435,7 +435,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-postgresql/v10/postgresql/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 1fd01042-3b70-4612-ac19-9ced0b2a1525
@@ -453,7 +453,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-postgresql/v10/postgresql-database/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: cabd3125-5a13-46ea-afad-a69582af9578
@@ -471,7 +471,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-postgresql/v10/postgresql-dbms/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: b43b4bba-5741-4d98-a10b-17dc5cee0175
@@ -489,7 +489,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-postgresql/v9.6/postgresql/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 25434f16-d762-41c7-bbdd-8045d7f74ca6
@@ -507,7 +507,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-postgresql/v9.6/postgresql-database/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: d3f74b44-79bc-4d1e-bf7d-c247c2b851f9
@@ -525,7 +525,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-postgresql/v9.6/postgresql-dbms/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 0346088a-d4b2-4478-aa32-f18e295ec1d9
@@ -543,7 +543,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-rediscache/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 6dc44338-2f13-4bc5-9247-5b1b3c5462d3
@@ -561,7 +561,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-servicebus/servicebus-namespace/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 0e93fbb8-7904-43a5-82db-81c7d3886a24
@@ -579,7 +579,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-servicebus/servicebus-queue/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: dc6d1545-4391-4c7e-ac7e-a8463787fb93
@@ -597,7 +597,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-servicebus/servicebus-topic/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 1a5b4582-29a3-48c5-9cac-511fd8c52756
@@ -615,7 +615,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-storage/blob-account/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: d799916e-3faf-4bdf-a48b-bf5012a2d38c
@@ -633,7 +633,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-storage/blob-account-and-container/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: fb6ce656-c16d-4b48-aff9-286714298af8
@@ -651,7 +651,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-storage/blob-container/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: d10ea062-b627-41e8-a240-543b60030694
@@ -669,7 +669,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-storage/v1-storage-account/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 9a3e28fe-8c02-49da-9b35-1b054eb06c95
@@ -687,7 +687,7 @@ spec:
       url: '{{ .Values.addonsRepositoryURL }}'
       filter: docs/azure-storage/v2-storage-account/
 ---
-apiVersion: rafter.kyma-project.io/v1alpha1
+apiVersion: rafter.kyma-project.io/v1beta1
 kind: AssetGroup
 metadata:
   name: 8f6c848a-4ce1-4a69-9248-63545d3e7e9c

--- a/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/job.yaml
+++ b/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/job.yaml
@@ -27,15 +27,15 @@ spec:
                       - |
                           while true
                           do
-                            echo "Get list of not ready DocsTopic:"
-                            lines=$(kubectl get DocsTopic -l chart=${LABEL_CHART},release=${LABEL_RELEASE} -n ${NS} \
+                            echo "Get list of not ready AssetGroup:"
+                            lines=$(kubectl get AssetGroup -l chart=${LABEL_CHART},release=${LABEL_RELEASE} -n ${NS} \
                               --no-headers -o custom-columns=name:.metadata.name,phase:.status.phase | awk '$2!="Ready"' | wc -l)
 
-                            echo "Got ${lines} not ready Docs Topic"
+                            echo "Got ${lines} not ready Asset Group"
 
                             if [[ "${lines}" -eq "0" ]];
                             then
-                                echo "Every DocsTopic is processed. Completed."
+                                echo "Every AssetGroup is processed. Completed."
                                 exit 0
                             fi
                             sleep 3

--- a/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/role.yaml
+++ b/addons/azure-service-broker-0.0.1/chart/azure-service-broker/templates/docu/role.yaml
@@ -8,7 +8,7 @@ metadata:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
 rules:
-    - apiGroups: ["cms.kyma-project.io"]
-      resources: ["docstopics"]
+    - apiGroups: ["rafter.kyma-project.io"]
+      resources: ["assetgroups"]
       verbs: ["list"]
 ---

--- a/addons/gcp-service-broker-0.1.0/chart/gcp-service-broker/templates/docu/docs.yaml
+++ b/addons/gcp-service-broker-0.1.0/chart/gcp-service-broker/templates/docu/docs.yaml
@@ -1,9 +1,9 @@
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: f80c0a3e-bd4d-4809-a900-b4e33a6450f1
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -15,12 +15,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-bigquery.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: b8e19880-ac58-42ef-b033-f7cd9c94d1fe
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -32,12 +32,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-bigtable.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: 4bc59b9a-8520-409f-85da-1c7552315863
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -49,12 +49,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-cloudsql-mysql.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: cbad6d78-a73c-432d-b8ff-b219a17a803a
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -66,12 +66,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-cloudsql-postgres.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: 3e897eb3-9062-4966-bd4f-85bda0f73b3d
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -83,12 +83,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-dataflow.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: 76d4abb2-fee7-4c8f-aee1-bcea2837f02b
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -100,12 +100,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-datastore.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: e84b69db-3de9-4688-8f5c-26b9d5b1f129
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -117,12 +117,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-dialogflow.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: 494eb82e-c4ca-4bed-871d-9c3f02f66e01
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -134,12 +134,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-filestore.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: a2b7b873-1e34-4530-8a42-902ff7d66b43
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -151,12 +151,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-firestore.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: 3ea92b54-838c-4fe1-b75d-9bda513380aa
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -169,12 +169,12 @@ spec:
       url: "{{ .Values.brokerDocBasePath }}/google-memorystore-redis.md"
 
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: 5ad2dce0-51f7-4ede-8b46-293d6df1e8d4
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -186,12 +186,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-ml-apis.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: 628629e3-79f5-4255-b981-d14c6c7856be
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -203,12 +203,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-pubsub.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: 51b3e27e-d323-49ce-8c5f-1211e6409e82
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -220,12 +220,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-spanner.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: 83837945-1547-41e0-b661-ea31d76eed11
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -237,12 +237,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-stackdriver-debugger.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: 2bc0d9ed-3f68-4056-b842-4a85cfbc727f
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -254,12 +254,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-stackdriver-monitoring.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: 00b9ca4a-7cd6-406a-a5b7-2f43f41ade75
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -271,12 +271,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-stackdriver-profiler.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -288,12 +288,12 @@ spec:
       mode: single
       url: "{{ .Values.brokerDocBasePath }}/google-stackdriver-trace.md"
 ---
-apiVersion: cms.kyma-project.io/v1alpha1
-kind: DocsTopic
+apiVersion: rafter.kyma-project.io/v1beta1
+kind: AssetGroup
 metadata:
   name: b9e4332e-b42b-4680-bda5-ea1506797474
   labels:
-    cms.kyma-project.io/view-context: service-catalog
+    rafter.kyma-project.io/view-context: service-catalog
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:

--- a/addons/gcp-service-broker-0.1.0/chart/gcp-service-broker/templates/docu/job.yaml
+++ b/addons/gcp-service-broker-0.1.0/chart/gcp-service-broker/templates/docu/job.yaml
@@ -27,15 +27,15 @@ spec:
                       - |
                           while true
                           do
-                            echo "Get list of not ready DocsTopic:"
-                            lines=$(kubectl get DocsTopic -l chart=${LABEL_CHART},release=${LABEL_RELEASE} -n ${NS} \
+                            echo "Get list of not ready AssetGroup:"
+                            lines=$(kubectl get AssetGroup -l chart=${LABEL_CHART},release=${LABEL_RELEASE} -n ${NS} \
                               --no-headers -o custom-columns=name:.metadata.name,phase:.status.phase | awk '$2!="Ready"' | wc -l)
 
-                            echo "Got ${lines} not ready Docs Topic"
+                            echo "Got ${lines} not ready Asset Group"
 
                             if [[ "${lines}" -eq "0" ]];
                             then
-                                echo "Every DocsTopic is processed. Completed."
+                                echo "Every AssetGroup is processed. Completed."
                                 exit 0
                             fi
                             sleep 3

--- a/addons/gcp-service-broker-0.1.0/chart/gcp-service-broker/templates/docu/role.yaml
+++ b/addons/gcp-service-broker-0.1.0/chart/gcp-service-broker/templates/docu/role.yaml
@@ -8,7 +8,7 @@ metadata:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
 rules:
-    - apiGroups: ["cms.kyma-project.io"]
-      resources: ["docstopics"]
+    - apiGroups: ["rafter.kyma-project.io"]
+      resources: ["assetgroups"]
       verbs: ["list"]
 ---


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Rename DocsTopics to AssetGroups in broker charts