### PR TITLE
Fix a variable name in the command

### DIFF
--- a/addons/gcp-service-broker-0.1.0/docs/broker/overview.md
+++ b/addons/gcp-service-broker-0.1.0/docs/broker/overview.md
@@ -12,7 +12,7 @@ The MySQL database is used to keep the broker's state. You can configure an exte
 
 ## Create a Secret
 
-To add the GCP Service Broker to your Namespace, prepare a service account and a JSON access key. 
+To add the GCP Service Broker to your Namespace, prepare a service account and a JSON access key.
 
 Follow these steps to create a Kubernetes Secret which contains a JSON access key:
 
@@ -30,7 +30,7 @@ Follow these steps to create a Kubernetes Secret which contains a JSON access ke
 
 7. Create a Secret from the JSON file by running this command:
 
-        kubectl create secret generic gcp-broker-data --from-file=sa-key={filename} --from-literal=project-name={gcp-project} --namespace {namespace}
+        kubectl create secret generic gcp-broker-data --from-file=sa-key={FILENAME} --from-literal=project-name={GCP_PROJECT_ID} --namespace {NAMESPACE}
 
 8. Click **Done**.
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The GCP Broker documentation includes the line:
```
kubectl create secret generic gcp-broker-data --from-file=sa-key={filename} --from-literal=project-name={gcp-project} --namespace {namespace}
```

To spare possible confusion for users, it might be cunning to replace `gcp-project` with `gcp-project-id`, as it is the project ID (and not project name) that is required. 


Changes proposed in this pull request:

- Fix a variable name in the command from {gcp-project} to {GCP_PROJECT_ID}

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
