### PR TITLE
Add the documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-improvement.md
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.md
@@ -1,0 +1,34 @@
+---
+name: Documentation improvement
+about: Suggest an improvement or report a bug in the documentation
+---
+
+<!-- Thank you for your contribution. Before you submit the issue:
+1. Search open and closed issues for duplicates.
+2. Read the contributing guidelines.
+3. Assign the Documentation project.
+-->
+
+**Description**
+
+<!-- Provide a clear and concise description of the potential documentation improvement.-->
+
+**Area**
+
+<!-- Provide the area the document refers to. For example, write: 
+* Application Connector
+* Event Mesh
+* Kyma Environment Broker
+* Rafter -->
+
+**Reasons**
+
+<!-- Explain why we should improve the document. -->
+
+**Assignees**
+
+@technical-writers
+
+**Attachments**
+
+<!-- Attach any files, links, code samples, or screenshots that will convince us to your idea. -->


### PR DESCRIPTION
**Description**

To improve the process of creating documentation and the work of technical writers, we put a documentation issue template in place to use when creating a documentation-related issue. 

Changes proposed in this pull request:

- Add the documentation issue template to issue templates for this repository.