### PR TITLE
Remove @mszostok from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of the `kyma-addons` repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @polskikiel @mszostok @piotrmiskiewicz @PK85 @jasiu001 @adamwalach @ksputo @kjaksik @crabtree
+* @polskikiel @piotrmiskiewicz @PK85 @jasiu001 @adamwalach @ksputo @kjaksik @crabtree
 
 # All .md files
 *.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @superojla


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Mateusz left Kyma in August and has not continued contributing to our project since then. According to the [offboarding guidelines](https://kyma-project.io/community/governance#kyma-working-model-kyma-working-model-when-does-a-maintainer-lose-the-maintainer-status), a person should be removed from codeowners in case they are no longer interested in contributing or haven't contributed to the project for more than 3 months. 

Changes proposed in this pull request:

- Remove @mszostok from CODEOWNERS