### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of the `kyma-addons` repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @polskikiel @piotrmiskiewicz @PK85 @jasiu001 @adamwalach @ksputo @kjaksik @crabtree
+* @piotrmiskiewicz @PK85 @jasiu001 @adamwalach @ksputo @crabtree
 
 # All .md files
-*.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @superojla
+*.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Recently, Karol Jaksik, Michał Kempski, and Justyna Sztyper left the company. According to the [offboarding guidelines](https://kyma-project.io/community/governance#kyma-working-model-kyma-working-model-when-does-a-maintainer-lose-the-maintainer-status), a person should be removed from codeowners in case they are no longer interested in contributing or haven't contributed to the project for more than 3 months. Also, Nina Hingerl went through the probationary period and thus should be added to codeowners.

Changes proposed in this pull request:
- Remove `kjaksik` from codeowners
- Remove `polskikiel` from codeowners
- Remove `superojla` from codeowners
- Add `NHingerl` to codeowners

**Related issue(s)**
https://github.tools.sap/kyma/community/issues/80
https://github.tools.sap/kyma/community/issues/88