### PR TITLE
Remove kazydek from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 * @piotrmiskiewicz @PK85 @jasiu001 @adamwalach @ksputo @crabtree
 
 # All .md files
-*.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl
+*.md @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl


### PR DESCRIPTION
**Description**

As Karolina is no longer an active contributor to the project, she must be removed from the CODEOWNERS.

Changes proposed in this pull request:

- Remove @kazydek from CODEOWNERS